### PR TITLE
Avoid undesired changes to appear in the order or uses addresses

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -272,8 +272,8 @@ module Spree
       self.user           = user
       self.email          = user.email if override_email
       self.created_by   ||= user
-      self.bill_address ||= user.bill_address
-      self.ship_address ||= user.ship_address
+      self.bill_address ||= user.bill_address.dup
+      self.ship_address ||= user.ship_address.dup
 
       changes = slice(:user_id, :email, :created_by_id, :bill_address_id, :ship_address_id)
 


### PR DESCRIPTION
By duplicating the addresses stored in the user, we avoid doing changes in the order address when editing the user address and vice versa.