### PR TITLE
Set false as default value for `Spree::Adjustment#included`

### DIFF
--- a/core/app/models/concerns/spree/adjustment_source.rb
+++ b/core/app/models/concerns/spree/adjustment_source.rb
@@ -9,7 +9,7 @@ module Spree
 
     protected
 
-    def create_adjustment(order, adjustable, included = nil)
+    def create_adjustment(order, adjustable, included = false)
       amount = compute_amount(adjustable)
       return if amount == 0
       adjustments.new(order: order,


### PR DESCRIPTION
Creating an adjustment with `included` as `nil` we are not able to get it with the `additional` and `is_included` [scopes](https://github.com/theam/spree/blob/3-1-stable/core/app/models/spree/adjustment.rb#L67-L68) and that gives troubles when calculating totals with gems like [spree_paypal_express](https://github.com/theam/better_spree_paypal_express/blob/3-1-stable/app/controllers/spree/paypal_controller.rb#L8)