### PR TITLE
Fix discontinued filter in admin products index

### DIFF
--- a/backend/app/controllers/spree/admin/products_controller.rb
+++ b/backend/app/controllers/spree/admin/products_controller.rb
@@ -105,7 +105,7 @@ module Spree
         return @collection if @collection.present?
         params[:q] ||= {}
         params[:q][:deleted_at_null] ||= "1"
-        params[:q][:not_discontinued] ||= "1"
+        params[:q][:discontinue_on_null] ||= "1"
 
         params[:q][:s] ||= "name asc"
         @collection = super


### PR DESCRIPTION
This issue was already solved in the Spree's master branch https://github.com/spree/spree/pull/7686, so, based on it, I'm solving it for our 3-1-stable branch